### PR TITLE
Fix unhandled exception in BeaconEye.

### DIFF
--- a/BeaconEye.cs
+++ b/BeaconEye.cs
@@ -302,17 +302,24 @@ namespace BeaconEye {
 
                 ScanResult sr;
 
-                if ((sr = IsBeaconProcess(process, monitor)).State == ScanState.Found || sr.State == ScanState.FoundNoKeys) {
-                    beaconsFound++;
-                    Console.ForegroundColor = ConsoleColor.Red;
-                    Console.WriteLine($"  {process.Name} ({process.ProcessId}), Keys Found:{sr.State == ScanState.Found}, Configuration Address: 0x{sr.ConfigAddress} {(sr.CrossArch ? $"(Please use the {(process.Is64Bit ? "x64" : "x86")} version of BeaconEye to monitor)" : "")}");
-                    sr.Configuration.PrintConfiguration(Console.Out, 1);
-                } else if(sr.State == ScanState.NotFound && verbose) {
-                    Console.ForegroundColor = ConsoleColor.Green;
-                    Console.WriteLine($"  {process.Name} ({process.ProcessId})");
-                } else if(sr.State == ScanState.HeapEnumFailed) {
-                    Console.ForegroundColor = ConsoleColor.Yellow;
-                    Console.WriteLine($"  {process.Name} ({process.ProcessId}) Failed to fetch heap info");
+                try
+                {
+                    if ((sr = IsBeaconProcess(process, monitor)).State == ScanState.Found || sr.State == ScanState.FoundNoKeys) {
+                        beaconsFound++;
+                        Console.ForegroundColor = ConsoleColor.Red;
+                        Console.WriteLine($"  {process.Name} ({process.ProcessId}), Keys Found:{sr.State == ScanState.Found}, Configuration Address: 0x{sr.ConfigAddress} {(sr.CrossArch ? $"(Please use the {(process.Is64Bit ? "x64" : "x86")} version of BeaconEye to monitor)" : "")}");
+                        sr.Configuration.PrintConfiguration(Console.Out, 1);
+                    } else if(sr.State == ScanState.NotFound && verbose) {
+                        Console.ForegroundColor = ConsoleColor.Green;
+                        Console.WriteLine($"  {process.Name} ({process.ProcessId})");
+                    } else if(sr.State == ScanState.HeapEnumFailed) {
+                        Console.ForegroundColor = ConsoleColor.Yellow;
+                        Console.WriteLine($"  {process.Name} ({process.ProcessId}) Failed to fetch heap info");
+                    }
+                }
+                catch (NtException e)
+                {
+                    Console.Error.WriteLine($"WARN: NtException \"{e.Status}\" for process {process.ProcessId} ({process.Name}).");
                 }
 
                 processesScanned++;

--- a/BeaconEye.cs
+++ b/BeaconEye.cs
@@ -319,7 +319,7 @@ namespace BeaconEye {
                 }
                 catch (NtException e)
                 {
-                    Console.Error.WriteLine($"WARN: NtException \"{e.Status}\" for process {process.ProcessId} ({process.Name}).");
+                    Console.Error.WriteLine($"[!] NtException \"{e.Status}\" for process {process.ProcessId} ({process.Name}).");
                 }
 
                 processesScanned++;


### PR DESCRIPTION
This PR addresses an unhandled exception when scanning processes from an elevated process.

```
PS C:\BeaconEye> .\BeaconEye.exe
BeconEye by @_EthicalChaos_
  CobaltStrike beacon hunter and command monitoring tool x86_64

[+] Scanning for beacon processess...

Unhandled Exception: NtApiDotNet.NtException: (0xC0000005) - The instruction at 0x%p referenced memory at 0x%p. The memory could not be %s.
   at NtApiDotNet.NtObjectUtils.ToNtException(NtStatus status, Boolean throw_on_error)
   at NtApiDotNet.NtVirtualMemory.ReadMemory[T](SafeKernelObjectHandle process, Int64 base_address)
   at BeaconEye.NtProcessReader.ReadMemory[T](UInt64 address)
   at BeaconEye.ProcessReader.get_Heaps()
   at BeaconEye.BeaconEye.ProcessHasConfig(ProcessReader process)
   at BeaconEye.BeaconEye.IsBeaconProcess(ProcessReader process, Boolean monitor)
   at BeaconEye.BeaconEye.Main(String[] args)
```

`NtApiDotNet` can throw an `NtException` with the status `STATUS_ACCESS_VIOLATION` on some processes.

This change simply wraps the process enumeration loop in a `try/catch` and prints a warning when such an exception is thrown.

```
PS C:\BeaconEye> .\BeaconEye.exe
BeconEye by @_EthicalChaos_
  CobaltStrike beacon hunter and command monitoring tool x86_64

[+] Scanning for beacon processess...
[!] NtException "STATUS_ACCESS_VIOLATION" for process 1052 (LsaIso.exe).
[+] Scanned 226 processes in 00:00:02.0509094
[=] No beacon processes found
```